### PR TITLE
Add Button Trailer Youtube 

### DIFF
--- a/game_list.php
+++ b/game_list.php
@@ -10,8 +10,9 @@ include 'includes/pagination.php';       // Include pagination logic
 <head>
     <title>GamePulse - Discover Exciting Games</title>
     <!-- Include Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet"/>
+
     <!-- Include jQuery and Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.min.js"></script>
@@ -128,6 +129,7 @@ include 'includes/pagination.php';       // Include pagination logic
                     <th><a href="?sort=<?php echo ($sort === 'newest') ? 'oldest' : 'newest'; ?>">Release Date</a></th>
                     <th><a href = "?sort=<?=($sort === 'highest') ? 'lowest' : 'highest'; ?>"> Sales Numbers (Approx) </a></th>
                     <th>Contributor</th>
+                    <th>Trailer</th>
                     <th>Actions</th>
                 </tr>
                 </thead>
@@ -140,8 +142,11 @@ include 'includes/pagination.php';       // Include pagination logic
                             <td><?php echo $game['sales_numbers']; ?></td>
                             <td><?php echo $game['github_username']; ?></td>
                             <td>
-                            <button class="btn btn-primary btn-details">Details</button>
-                        </td>
+                                <?php if (!empty($game['youtube_trailer'])) : ?>
+                                    <a class="btn btn-primary btn-trailer" href="<?php echo $game['youtube_trailer']; ?>" target="_blank">Watch Trailer</a>
+                                <?php endif; ?>
+                            </td>
+                            <td><button class="btn btn-primary btn-details">Details</button></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>
@@ -218,6 +223,9 @@ include 'includes/pagination.php';       // Include pagination logic
 
                 // Show the modal manually
                 $("#gameModal").modal("show");
+            });
+
+            $(".btn-trailer").on("click", function() {
             });
         });
     </script>

--- a/includes/footer.inc.php
+++ b/includes/footer.inc.php
@@ -1,8 +1,6 @@
 <style>
     .border-top { border-top: 2px solid grey!important;}
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-xrR5KFN6dPnp6t6YSngP5w7tLF/JQqU2t7Hw/2+3XIfjgpdW+6jzjIg6tYYz8GBC4q9BRTt9h1pDmCdhzVV57w==" crossorigin="anonymous" />
-
 <div >
 <footer class="footer bg-dark text-light py-5 px-5 border-top" style="padding-bottom: 1rem!important;">
     <div class="row" style="justify-content: space-between;">

--- a/includes/games_data.php
+++ b/includes/games_data.php
@@ -7,6 +7,7 @@ $games = [
         'release_date' => '2016-12-06',
         'sales_numbers' => '2,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/4cDuKShhQOA?si=GGnzRIIrznF-35-n'
     ],
     [
         'title' => 'Dark and Darker',
@@ -14,6 +15,7 @@ $games = [
         'release_date' => '2023-04-15',
         'sales_numbers' => '1,500,000',
         'github_username' => 'Doononthon',
+        'youtube_trailer' => 'https://youtu.be/vKZll_JKBvk?si=lkmQNml7ehaIXsrB'
     ],
     [
         'title' => 'The Elder Scrolls V: Skyrim',
@@ -21,6 +23,7 @@ $games = [
         'release_date' => '2011-11-11',
         'sales_numbers' => '30,000,000+',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/JSRtYpNRoN0?si=hMTtiK8kvR8xxxkc'
     ],
     [
         'title' => 'Overwatch',
@@ -28,6 +31,8 @@ $games = [
         'release_date' => '2016-05-24',
         'sales_numbers' => '50,000,000+',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/dushZybUYnM?si=wLbTYZXF974zbYgA'
+        
     ],
     [
         'title' => 'Assassin\'s Creed Valhalla',
@@ -35,6 +40,7 @@ $games = [
         'release_date' => '2020-11-10',
         'sales_numbers' => '14,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/ssrNcwxALS4?si=wZsHxEr8COsGgm3R'
     ],
     [
         'title' => 'The Witcher 3: Wild Hunt',
@@ -42,6 +48,7 @@ $games = [
         'release_date' => '2015-05-19',
         'sales_numbers' => '30,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/XHrskkHf958?si=3mZB4P0WIcst_I4E'
     ],
     [
         'title' => 'The Legend of Zelda: Breath of the Wild',
@@ -49,6 +56,8 @@ $games = [
         'release_date' => '2017-03-03',
         'sales_numbers' => '22,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/zw47_q9wbBE?si=1WeOiN2rrcHqqU4j'
+        
     ],
     [
         'title' => 'Minecraft',
@@ -56,6 +65,7 @@ $games = [
         'release_date' => '2011-11-18',
         'sales_numbers' => '238,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/MmB9b5njVbA?si=DF8iQGAIboOcyVER'
     ],
     [
         'title' => 'Fortnite',
@@ -63,6 +73,7 @@ $games = [
         'release_date' => '2017-07-25',
         'sales_numbers' => '350,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/WJW-bzXZM8M?si=YPjHOr0MSpRZBrMS'
     ],
     [
         'title' => 'Among Us',
@@ -70,6 +81,7 @@ $games = [
         'release_date' => '2018-06-15',
         'sales_numbers' => '500,000,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => ''
     ],
     [
         'title' => 'Red Dead Redemption 2',
@@ -77,6 +89,7 @@ $games = [
         'release_date' => '2018-10-26',
         'sales_numbers' => '38,000,000',
         'github_username' => 'LilMaddy',
+        'youtube_trailer' => 'https://youtu.be/gmA6MrX81z4?si=cuOASskCKMPoJxhj'
     ],
     [
         'title' => 'Horizon Zero Dawn',
@@ -84,6 +97,7 @@ $games = [
         'release_date' => '2017-02-28',
         'sales_numbers' => '10,000,000',
         'github_username' => 'Legen32',
+        'youtube_trailer' => 'https://youtu.be/lwI6-jKlsO0?si=1LkRtwkalDvYgwlD'
     ],
     [
         'title' => 'Grand Theft Auto V',
@@ -91,6 +105,7 @@ $games = [
         'release_date' => '2013-09-17',
         'sales_numbers' => '140,000,000',
         'github_username' => 'tetawiah',
+        'youtube_trailer' => 'https://youtu.be/QkkoHAzjnUs?si=RMlggjzkAhgMm8E0'
     ],
     [
         'title' => 'Tetris',
@@ -98,6 +113,7 @@ $games = [
         'release_date' => '1984-06-06',
         'sales_numbers' => '170,000,000',
         'github_username' => 'tetawiah',
+        'youtube_trailer' => ''
     ],
     [
         'title' => 'Call of Duty: Modern Warfare 2',
@@ -105,6 +121,7 @@ $games = [
         'release_date' => '2009-11-10',
         'sales_numbers' => '22,700,000',
         'github_username' => 'tetawiah',
+        'youtube_trailer' => 'https://youtu.be/blshENwbHgs?si=RvCfdjxmnu3ZN_cq'
     ],
     [
         'title' => 'Elden Ring',
@@ -112,6 +129,7 @@ $games = [
         'release_date' => '2022-02-25',
         'sales_numbers' => '20,500,000',
         'github_username' => 'harrydemorgan',
+        'youtube_trailer' => 'https://youtu.be/E3Huy2cdih0?si=QUqdQKV1iAQ7oOem'
     ],
     [
         'title' => 'Counter-Strike: Global Offensive',
@@ -119,6 +137,7 @@ $games = [
         'release_date' => '2012-08-21',
         'sales_numbers' => '45,000,000+',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/edYCtaNueQY?si=DYgPJi5VcqoaAbvq'
     ],
     [
         'title' => 'Beat Saber',
@@ -126,6 +145,7 @@ $games = [
         'release_date' => '2018-05-01',
         'sales_numbers' => '6,000,000+',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/vL39Sg2AqWg?si=BxSVUNGlBe0Obfsp'
     ],
     [
         'title' => 'Resident Evil 8: Village',
@@ -133,6 +153,7 @@ $games = [
         'release_date' => '2021-05-07',
         'sales_numbers' => '8,000,000+',
         'github_username' => 'Omanshu209',
+        'youtube_trailer' => 'https://youtu.be/QKocYiRHYlI?si=S0O2Ebj2HBaQcUn8'
     ],
     [
         'title' => 'Mount & Blade II: Bannerlord',
@@ -140,6 +161,7 @@ $games = [
         'release_date' => '2022-10-25',
         'sales_numbers' => '3,100,000+',
         'github_username' => 'AlandisAyupov',
+        'youtube_trailer' => 'https://youtu.be/q6oH5cW7PaA?si=N8ErmmYQkhik2Jni'
     ],
     [
         'title' => 'Cyberpunk 2077',
@@ -147,6 +169,7 @@ $games = [
         'release_date' => '2020-12-10',
         'sales_numbers' => '20,000,000+',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/P99qJGrPNLs?si=qWBJiwM9YiM2n6aG'
     ],
     [
         'title' => 'God of War Ragnarök',
@@ -154,6 +177,7 @@ $games = [
         'release_date' => '2022-11-09',
         'sales_numbers' => '11,000,000+',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/EE-4GvjKcfs?si=dr7amhqzGZdbmcYk'
     ],
     [
         'title' => 'The Last of Us 2',
@@ -161,6 +185,7 @@ $games = [
         'release_date' => '2020-19-06',
         'sales_numbers' => '10,000,000+',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/qPNiIeKMHyg?si=Eboyxfo0noDkdKtD'
     ],
     [
         'title' => 'Phasmophobia',
@@ -168,6 +193,7 @@ $games = [
         'release_date' => '2020-9-18',
         'sales_numbers' => '5,000,000+',
         'github_username' => 'Omanshu209',
+        'youtube_trailer' => 'https://youtu.be/sRa9oeo5KiY?si=3fEwnQBdImft3lhG'
     ],
     [
         'title' => 'Infliction',
@@ -175,6 +201,7 @@ $games = [
         'release_date' => '2018-10-17',
         'sales_numbers' => '4,000,000+',
         'github_username' => 'Omanshu209',
+        'youtube_trailer' => ''
     ],
     [
         'title' => 'MADiSON',
@@ -182,6 +209,7 @@ $games = [
         'release_date' => '2022-07-08',
         'sales_numbers' => '3,000,000+',
         'github_username' => 'Omanshu209',
+        'youtube_trailer' => 'https://youtu.be/Il_TFl_vPoo?si=pU6-dcsvz4Xbmf-v'
     ],
     [
         'title' => 'Mount & Blade: Warband',
@@ -189,6 +217,7 @@ $games = [
         'release_date' => '2010-03-30',
         'sales_numbers' => '6,000,000+',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/hwGxzdGqEDg?si=MXfVo49M1-bXLH90'
     ],
     [
         'title' => 'Pummel Party',
@@ -196,62 +225,7 @@ $games = [
         'release_date' => '2018-09-20',
         'sales_numbers' => 'Over 1,000,000 on Steam',
         'github_username' => 'DoonOnthon',
-    ],
-    [
-        'title' => 'Pummel Party',
-        'category' => 'Party Game',
-        'release_date' => '2018-09-20',
-        'sales_numbers' => 'Over 1,000,000 on Steam',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'Mount & Blade: Warband',
-        'category' => 'Action RPG',
-        'release_date' => '2010-03-30',
-        'sales_numbers' => '6,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'MADiSON',
-        'category' => 'Adventure',
-        'release_date' => '2022-07-08',
-        'sales_numbers' => '3,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'Infliction',
-        'category' => 'Adventure',
-        'release_date' => '2018-10-17',
-        'sales_numbers' => '4,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'Phasmophobia',
-        'category' => 'Adventure',
-        'release_date' => '2020-9-18',
-        'sales_numbers' => '5,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'The Last of Us 2',
-        'category' => 'Action-Adventure',
-        'release_date' => '2020-19-06',
-        'sales_numbers' => '10,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'God of War Ragnarök',
-        'category' => 'Action-Adventure',
-        'release_date' => '2022-11-09',
-        'sales_numbers' => '11,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
-    ],
-    [
-        'title' => 'Cyberpunk 2077',
-        'category' => 'Action-Adventure',
-        'release_date' => '2020-12-10',
-        'sales_numbers' => '20,000,000+',
-        'github_username' => 'IamSudhir-Kumar',
+        'youtube_trailer' => 'https://youtu.be/oiYG0Ov5jKE?si=a1A_NorgQkWtrdRX'
     ],
     [
         'title' => "Tom Clancy's Rainbow Six Siege",
@@ -259,6 +233,7 @@ $games = [
         'release_date' => '2015-12-01',
         'sales_numbers' => '36,000,000+',
         'github_username' => 'lucas-dantas10',
+        'youtube_trailer' => 'https://youtu.be/wV8QCvZXmZQ?si=yc4I57R0zxPUoYE0'
     ],
     [
         'title' => 'Rocket League',
@@ -266,6 +241,7 @@ $games = [
         'release_date' => '2015-07-07',
         'sales_numbers' => '10,000,000+',
         'github_username' => 'lucas-dantas10',
+        'youtube_trailer' => 'https://youtu.be/SgSX3gOrj60?si=A1v9PMTCS09g2kaW'
     ],
     [
         'title' => 'Hearthstone',
@@ -273,6 +249,7 @@ $games = [
         'release_date' => '2014-03-11',
         'sales_numbers' => '5,000,000+',
         'github_username' => 'lucas-dantas10',
+        'youtube_trailer' => ''
     ],
     [
         'title' => 'New World',
@@ -280,6 +257,7 @@ $games = [
         'release_date' => '2021-09-28',
         'sales_numbers' => '700,000+',
         'github_username' => 'lucas-dantas10',
+        'youtube_trailer' => 'https://youtu.be/m1C5dLnvlzg?si=zXaKkDj4d7nVDY-o'
     ],
     [
         'title' => 'Kingdom Hearts',
@@ -287,6 +265,7 @@ $games = [
         'release_date' => '2002-03-28',
         'sales_numbers' => '100,000,000+',
         'github_username' => 'Emma-Jonna',
+        'youtube_trailer' => 'https://youtu.be/CzgrMWisdU0?si=nDyBCyoLhxbQ51nr'
     ],
     [
         'title' => 'Untitled Goose Game',
@@ -294,6 +273,7 @@ $games = [
         'release_date' => '2019-09-20',
         'sales_numbers' => '5,000,000+',
         'github_username' => 'Emma-Jonna',
+        'youtube_trailer' => 'https://youtu.be/9LL2AtHo1gk?si=ZWPzWl4CQOvWpK09'
     ],
     [
         'title' => 'Ōkami',
@@ -301,6 +281,7 @@ $games = [
         'release_date' => '2006-04-20',
         'sales_numbers' => '4,000,000+',
         'github_username' => 'Emma-Jonna',
+        'youtube_trailer' => 'https://youtu.be/RhnhRfTzRnw?si=-cekAx2tHem3FzdO'
     ],
     [
         'title' => 'Super Mario Odyssey',
@@ -308,6 +289,7 @@ $games = [
         'release_date' => '2017-10-27',
         'sales_numbers' => '20,230,000',
         'github_username' => 'adesh1998',
+        'youtube_trailer' => 'https://youtu.be/u6oPBIVjf8E?si=DMi5-Zv5M3VnVRBD'
     ],
     [
         'title' => 'Lethal Company',
@@ -315,6 +297,7 @@ $games = [
         'release_date' => '2023-06-15',
         'sales_numbers' => '12,500,000',
         'github_username' => 'DoonOnthon',
+        'youtube_trailer' => 'https://youtu.be/Su6OsTb1w9Q?si=bvBFc0vy9rfBR0NV'
     ],
     [
         'title' => 'Hogwarts Legacy',
@@ -322,6 +305,7 @@ $games = [
         'release_date' => '2023-02-10',
         'sales_numbers' => '15,000,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/BtyBjOW8sGY?si=cqs2MUSJP3PhTUPd'
     ],
     [
         'title' => 'Star Wars Jedi: Fallen Order',
@@ -329,6 +313,7 @@ $games = [
         'release_date' => '2019-11-15',
         'sales_numbers' => '10,000,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/0GLbwkfhYZk?si=MzQYmNfO-BC58b7_'
     ],
     [
         'title' => 'Star Wars Jedi: Survivor',
@@ -336,6 +321,7 @@ $games = [
         'release_date' => '2023-04-18',
         'sales_numbers' => '10,400,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/VRaobDJjiec?si=0cnwcDnJhDVFXOVs'
     ],
     [
         'title' => 'Baldurs Gate 3',
@@ -343,6 +329,7 @@ $games = [
         'release_date' => '2023-08-03',
         'sales_numbers' => '5,200,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/4YH9HPQ2xPg?si=PvjkqYjcV18cuUHs'
     ],
     [
         'title' => 'Marvels Spider-Man',
@@ -350,6 +337,7 @@ $games = [
         'release_date' => '2018-09-07',
         'sales_numbers' => '20,000,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/bbFh-Hbd81o?si=ZEUTsjBM-cxCIg2V'
     ],
     [
         'title' => 'Spider-Man: Miles Morales',
@@ -357,13 +345,15 @@ $games = [
         'release_date' => '2020-11-11',
         'sales_numbers' => '4,100,000',
         'github_username' => 'Camarota-234',
+        'youtube_trailer' => 'https://youtu.be/NTunTURbyUU?si=Q1ejrBZsG3HfLTDk'
     ],
     [
-        'title' => 'PUBG: Battlegrounds',
+        'title' => 'PUBG Battlegrounds',
         'category' => 'Battle Royale',
         'release_date' => '2017-12-20',
         'sales_numbers' => '75,000,000',
         'github_username' => 'dalek63',
+        'youtube_trailer' => 'https://youtu.be/S-6TBeruY6w?si=eUjkz2e3RYsVVA9n'
     ],
     [
         'title' => 'MarioKart 8 Deluxe',
@@ -371,13 +361,7 @@ $games = [
         'release_date' => '2017-04-28',
         'sales_numbers' => '65,570,000',
         'github_username' => 'dalek63',
-    ],
-    [
-        'title' => 'Red Dead Redemption II',
-        'category' => 'Action-Adventure',
-        'release_date' => '2018-10-26',
-        'sales_numbers' => '57,000,000',
-        'github_username' => 'dalek63',
+        'youtube_trailer' => 'https://youtu.be/tKlRN2YpxRE?si=Z7z6eCNKMDKKazRQ'
     ],
     [
         'title' => 'Wii Sports',
@@ -385,6 +369,7 @@ $games = [
         'release_date' => '2006-11-19',
         'sales_numbers' => '82,900,000',
         'github_username' => 'dalek63',
+        'youtube_trailer' => ''
     ],
     [
         'title' => 'Human: Fall Flat',
@@ -392,6 +377,7 @@ $games = [
         'release_date' => '2016-07-22',
         'sales_numbers' => '50,000,000',
         'github_username' => 'dalek63',
+        'youtube_trailer' => 'https://youtu.be/jNV4lCNEp_0?si=7vQPKct40TLNw0yM'
     ],
     [
         'title' => 'Terraria',
@@ -399,6 +385,7 @@ $games = [
         'release_date' => '2011-05-16',
         'sales_numbers' => '44,500,000',
         'github_username' => 'dalek63',
+        'youtube_trailer' => 'https://youtu.be/w7uOhFTrrq0?si=0Fp0x3Iw4gM2nWek'
     ],
     [
         'title' => 'Call of Duty: Modern Warfare 3',
@@ -406,7 +393,8 @@ $games = [
         'release_date' => '2011-11-08',
         'sales_numbers' => '26,500,000',
         'github_username' => 'dalek63',
+        'youtube_trailer' => 'https://youtu.be/coiTJbr9m04?si=kTgKUCAXX66GbURv'
     ],
-
+    
 
 ];


### PR DESCRIPTION
- Add 'youtube_trailer' to game_data folder which is the link to YouTube trailer
- Add button to watch game trailers, when you click on the button the game's trailer open in a YouTube page.
- This "youtube-trailer" field can be empty, in this case the button is disabled for games that don't have a link to a YouTube trailer 